### PR TITLE
Add privateNetworkClientServer capability to the client app

### DIFF
--- a/QuizGameClient/Package.appxmanifest
+++ b/QuizGameClient/Package.appxmanifest
@@ -25,5 +25,6 @@
   <Capabilities>
     <Capability Name="internetClientServer" />
     <Capability Name="internetClient" />
+    <Capability Name="privateNetworkClientServer" />
   </Capabilities>
 </Package>


### PR DESCRIPTION
the privateNetworkClientServer capability was needed to get the app to work on corporate network.